### PR TITLE
feat: two-stage retrieval with cross-encoder reranking

### DIFF
--- a/pkg/index/index.go
+++ b/pkg/index/index.go
@@ -577,136 +577,13 @@ func (idx *Indexer) indexFile(ctx context.Context, path string) error {
 // computeFileEmbeddings computes document-level embeddings by averaging chunk embeddings.
 // This enables document-level search for queries like "what does this repo do".
 func (idx *Indexer) computeFileEmbeddings(ctx context.Context) (int, error) {
-	// Check if store supports file embeddings
-	feStore, ok := idx.store.(store.FileEmbeddingStorer)
+	// Check if store supports computing file embeddings
+	computer, ok := idx.store.(store.FileEmbeddingComputer)
 	if !ok {
 		return 0, nil // Store doesn't support file embeddings
 	}
 
-	// Query all documents grouped by filepath
-	// We need to access the database directly since we need embeddings
-	libStore, ok := idx.store.(*store.LibSQLStore)
-	if !ok {
-		return 0, nil // Only LibSQLStore supports this currently
-	}
-
-	// Get list of unique file paths
-	rows, err := libStore.DB().QueryContext(ctx, `
-		SELECT DISTINCT filepath FROM documents
-	`)
-	if err != nil {
-		return 0, fmt.Errorf("query file paths: %w", err)
-	}
-
-	var filePaths []string
-	for rows.Next() {
-		var fp string
-		if err := rows.Scan(&fp); err != nil {
-			continue
-		}
-		filePaths = append(filePaths, fp)
-	}
-	_ = rows.Close()
-
-	if len(filePaths) == 0 {
-		return 0, nil
-	}
-
-	// Batch file embeddings for storage
-	var fileEmbeddings []*store.FileEmbedding
-	const batchSize = 100
-
-	for _, fp := range filePaths {
-		// Get all chunk embeddings for this file
-		embRows, err := libStore.DB().QueryContext(ctx, `
-			SELECT vector_extract(embedding), end_line
-			FROM documents
-			WHERE filepath = ? AND embedding IS NOT NULL
-			ORDER BY start_line
-		`, fp)
-		if err != nil {
-			continue
-		}
-
-		var embeddings [][]float32
-		var maxLine int
-		for embRows.Next() {
-			var vecStr string
-			var endLine int
-			if err := embRows.Scan(&vecStr, &endLine); err != nil {
-				continue
-			}
-			vec := parseVectorString(vecStr)
-			if vec != nil {
-				embeddings = append(embeddings, vec)
-				if endLine > maxLine {
-					maxLine = endLine
-				}
-			}
-		}
-		_ = embRows.Close()
-
-		if len(embeddings) == 0 {
-			continue
-		}
-
-		// Compute mean embedding
-		dims := len(embeddings[0])
-		meanEmb := make([]float32, dims)
-		for _, emb := range embeddings {
-			for i, v := range emb {
-				meanEmb[i] += v
-			}
-		}
-		scale := float32(1.0 / float64(len(embeddings)))
-		for i := range meanEmb {
-			meanEmb[i] *= scale
-		}
-
-		fileEmbeddings = append(fileEmbeddings, &store.FileEmbedding{
-			FilePath:   fp,
-			Embedding:  meanEmb,
-			ChunkCount: len(embeddings),
-			TotalLines: maxLine,
-		})
-
-		// Store in batches
-		if len(fileEmbeddings) >= batchSize {
-			if err := feStore.StoreFileEmbeddingBatch(ctx, fileEmbeddings); err != nil {
-				return 0, fmt.Errorf("store file embeddings: %w", err)
-			}
-			fileEmbeddings = nil
-		}
-	}
-
-	// Store remaining
-	if len(fileEmbeddings) > 0 {
-		if err := feStore.StoreFileEmbeddingBatch(ctx, fileEmbeddings); err != nil {
-			return 0, fmt.Errorf("store file embeddings: %w", err)
-		}
-	}
-
-	return len(filePaths), nil
-}
-
-// parseVectorString parses libSQL's vector string format "[1.0,2.0,3.0]"
-func parseVectorString(s string) []float32 {
-	s = strings.TrimPrefix(s, "[")
-	s = strings.TrimSuffix(s, "]")
-	if s == "" {
-		return nil
-	}
-
-	parts := strings.Split(s, ",")
-	vec := make([]float32, len(parts))
-	for i, p := range parts {
-		var v float64
-		if _, err := fmt.Sscanf(strings.TrimSpace(p), "%f", &v); err != nil {
-			return nil
-		}
-		vec[i] = float32(v)
-	}
-	return vec
+	return computer.ComputeAndStoreFileEmbeddings(ctx)
 }
 
 // validateAndRechunk checks chunks for token limit compliance and re-chunks oversized ones.

--- a/pkg/index/index.go
+++ b/pkg/index/index.go
@@ -419,6 +419,17 @@ func (idx *Indexer) Index(ctx context.Context) error {
 		stats.RecordStage("flush", flushDuration, 1)
 	}
 
+	// Compute document-level embeddings (mean of chunk embeddings per file)
+	fileEmbedTimer := util.NewTimer("file_embeddings")
+	fileCount, err := idx.computeFileEmbeddings(ctx)
+	fileEmbedDuration := fileEmbedTimer.Stop()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to compute file embeddings: %v\n", err)
+	} else if fileCount > 0 {
+		stats.RecordStage("file_embeddings", fileEmbedDuration, int64(fileCount))
+		util.Debugf(util.DebugSummary, "Computed %d file embeddings in %v", fileCount, fileEmbedDuration.Round(time.Millisecond))
+	}
+
 	elapsed := time.Since(startTime)
 	fmt.Printf("\rIndexed %d files in %v (%d errors)\n",
 		idx.processed, elapsed.Round(time.Millisecond), idx.errors)
@@ -561,6 +572,141 @@ func (idx *Indexer) indexFile(ctx context.Context, path string) error {
 		return nil
 	}
 	return idx.store.StoreBatch(ctx, docs)
+}
+
+// computeFileEmbeddings computes document-level embeddings by averaging chunk embeddings.
+// This enables document-level search for queries like "what does this repo do".
+func (idx *Indexer) computeFileEmbeddings(ctx context.Context) (int, error) {
+	// Check if store supports file embeddings
+	feStore, ok := idx.store.(store.FileEmbeddingStorer)
+	if !ok {
+		return 0, nil // Store doesn't support file embeddings
+	}
+
+	// Query all documents grouped by filepath
+	// We need to access the database directly since we need embeddings
+	libStore, ok := idx.store.(*store.LibSQLStore)
+	if !ok {
+		return 0, nil // Only LibSQLStore supports this currently
+	}
+
+	// Get list of unique file paths
+	rows, err := libStore.DB().QueryContext(ctx, `
+		SELECT DISTINCT filepath FROM documents
+	`)
+	if err != nil {
+		return 0, fmt.Errorf("query file paths: %w", err)
+	}
+
+	var filePaths []string
+	for rows.Next() {
+		var fp string
+		if err := rows.Scan(&fp); err != nil {
+			continue
+		}
+		filePaths = append(filePaths, fp)
+	}
+	_ = rows.Close()
+
+	if len(filePaths) == 0 {
+		return 0, nil
+	}
+
+	// Batch file embeddings for storage
+	var fileEmbeddings []*store.FileEmbedding
+	const batchSize = 100
+
+	for _, fp := range filePaths {
+		// Get all chunk embeddings for this file
+		embRows, err := libStore.DB().QueryContext(ctx, `
+			SELECT vector_extract(embedding), end_line
+			FROM documents
+			WHERE filepath = ? AND embedding IS NOT NULL
+			ORDER BY start_line
+		`, fp)
+		if err != nil {
+			continue
+		}
+
+		var embeddings [][]float32
+		var maxLine int
+		for embRows.Next() {
+			var vecStr string
+			var endLine int
+			if err := embRows.Scan(&vecStr, &endLine); err != nil {
+				continue
+			}
+			vec := parseVectorString(vecStr)
+			if vec != nil {
+				embeddings = append(embeddings, vec)
+				if endLine > maxLine {
+					maxLine = endLine
+				}
+			}
+		}
+		_ = embRows.Close()
+
+		if len(embeddings) == 0 {
+			continue
+		}
+
+		// Compute mean embedding
+		dims := len(embeddings[0])
+		meanEmb := make([]float32, dims)
+		for _, emb := range embeddings {
+			for i, v := range emb {
+				meanEmb[i] += v
+			}
+		}
+		scale := float32(1.0 / float64(len(embeddings)))
+		for i := range meanEmb {
+			meanEmb[i] *= scale
+		}
+
+		fileEmbeddings = append(fileEmbeddings, &store.FileEmbedding{
+			FilePath:   fp,
+			Embedding:  meanEmb,
+			ChunkCount: len(embeddings),
+			TotalLines: maxLine,
+		})
+
+		// Store in batches
+		if len(fileEmbeddings) >= batchSize {
+			if err := feStore.StoreFileEmbeddingBatch(ctx, fileEmbeddings); err != nil {
+				return 0, fmt.Errorf("store file embeddings: %w", err)
+			}
+			fileEmbeddings = nil
+		}
+	}
+
+	// Store remaining
+	if len(fileEmbeddings) > 0 {
+		if err := feStore.StoreFileEmbeddingBatch(ctx, fileEmbeddings); err != nil {
+			return 0, fmt.Errorf("store file embeddings: %w", err)
+		}
+	}
+
+	return len(filePaths), nil
+}
+
+// parseVectorString parses libSQL's vector string format "[1.0,2.0,3.0]"
+func parseVectorString(s string) []float32 {
+	s = strings.TrimPrefix(s, "[")
+	s = strings.TrimSuffix(s, "]")
+	if s == "" {
+		return nil
+	}
+
+	parts := strings.Split(s, ",")
+	vec := make([]float32, len(parts))
+	for i, p := range parts {
+		var v float64
+		if _, err := fmt.Sscanf(strings.TrimSpace(p), "%f", &v); err != nil {
+			return nil
+		}
+		vec[i] = float32(v)
+	}
+	return vec
 }
 
 // validateAndRechunk checks chunks for token limit compliance and re-chunks oversized ones.

--- a/pkg/rerank/reranker.go
+++ b/pkg/rerank/reranker.go
@@ -1,0 +1,247 @@
+package rerank
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"sort"
+	"sync"
+	"time"
+)
+
+// Config holds reranker configuration.
+type Config struct {
+	Endpoint  string        // Server endpoint (default: http://localhost:8081)
+	Timeout   time.Duration // Request timeout (default: 30s)
+	AutoStart bool          // Auto-start server if not running (default: true)
+	ServerMgr *RerankerManager
+}
+
+// DefaultConfig returns sensible defaults for reranker configuration.
+func DefaultConfig() Config {
+	return Config{
+		Endpoint:  "http://localhost:8081",
+		Timeout:   30 * time.Second,
+		AutoStart: true,
+	}
+}
+
+// Reranker handles document reranking via llama.cpp server.
+type Reranker struct {
+	endpoint   string
+	client     *http.Client
+	serverMgr  *RerankerManager
+	autoStart  bool
+	startOnce  sync.Once
+	startError error
+}
+
+// RerankResult contains the reranked document index and score.
+type RerankResult struct {
+	Index int     `json:"index"`
+	Score float64 `json:"relevance_score"`
+}
+
+// rerankRequest matches llama.cpp /v1/rerank endpoint format.
+type rerankRequest struct {
+	Model     string   `json:"model,omitempty"`
+	Query     string   `json:"query"`
+	Documents []string `json:"documents"`
+	TopN      int      `json:"top_n,omitempty"`
+}
+
+// rerankResponse from llama.cpp server.
+type rerankResponse struct {
+	Model   string         `json:"model"`
+	Results []RerankResult `json:"results"`
+}
+
+// New creates a new reranker with default configuration.
+func New() (*Reranker, error) {
+	mgr, err := NewRerankerManager()
+	if err != nil {
+		return nil, err
+	}
+
+	cfg := DefaultConfig()
+	cfg.ServerMgr = mgr
+	cfg.Endpoint = mgr.Endpoint()
+
+	return NewWithConfig(cfg), nil
+}
+
+// NewWithConfig creates a reranker with custom configuration.
+func NewWithConfig(cfg Config) *Reranker {
+	endpoint := cfg.Endpoint
+	if endpoint == "" {
+		endpoint = "http://localhost:8081"
+	}
+
+	timeout := cfg.Timeout
+	if timeout == 0 {
+		timeout = 30 * time.Second
+	}
+
+	return &Reranker{
+		endpoint:  endpoint,
+		client:    &http.Client{Timeout: timeout},
+		serverMgr: cfg.ServerMgr,
+		autoStart: cfg.AutoStart,
+	}
+}
+
+// ensureServer starts the reranker server if auto-start is enabled.
+func (r *Reranker) ensureServer() error {
+	if !r.autoStart || r.serverMgr == nil {
+		return nil
+	}
+
+	r.startOnce.Do(func() {
+		if !r.serverMgr.IsRunning() {
+			r.startError = r.serverMgr.Start()
+		}
+	})
+
+	return r.startError
+}
+
+// Rerank takes a query and list of document contents, returns reranked results.
+// Documents are reranked by relevance to the query. Higher scores indicate more relevance.
+func (r *Reranker) Rerank(ctx context.Context, query string, documents []string) ([]RerankResult, error) {
+	if len(documents) == 0 {
+		return nil, nil
+	}
+
+	// Ensure server is running
+	if err := r.ensureServer(); err != nil {
+		return nil, fmt.Errorf("failed to start reranker server: %w", err)
+	}
+
+	// Build request
+	reqBody, err := json.Marshal(rerankRequest{
+		Query:     query,
+		Documents: documents,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal rerank request: %w", err)
+	}
+
+	// Create HTTP request
+	req, err := http.NewRequestWithContext(ctx, "POST",
+		r.endpoint+"/v1/rerank", bytes.NewReader(reqBody))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create rerank request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	// Send request
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("rerank request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// Check status code
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("rerank returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	// Parse response
+	var result rerankResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to parse rerank response: %w", err)
+	}
+
+	return result.Results, nil
+}
+
+// RerankTopK reranks documents and returns only the top K results.
+func (r *Reranker) RerankTopK(ctx context.Context, query string, documents []string, k int) ([]RerankResult, error) {
+	results, err := r.Rerank(ctx, query, documents)
+	if err != nil {
+		return nil, err
+	}
+
+	// Sort by score descending (higher = more relevant)
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].Score > results[j].Score
+	})
+
+	// Limit to top K
+	if len(results) > k {
+		results = results[:k]
+	}
+
+	return results, nil
+}
+
+// IsAvailable checks if reranking is available (model downloaded and server can start).
+func (r *Reranker) IsAvailable() bool {
+	if r.serverMgr == nil {
+		return false
+	}
+
+	// Check if model exists
+	if !r.serverMgr.ModelExists() {
+		return false
+	}
+
+	// Check if server is running or can start
+	if r.serverMgr.IsRunning() {
+		return true
+	}
+
+	// Try to start server
+	if err := r.serverMgr.Start(); err != nil {
+		return false
+	}
+
+	return true
+}
+
+// Stop stops the reranker server if it was started by this reranker.
+func (r *Reranker) Stop() error {
+	if r.serverMgr == nil {
+		return nil
+	}
+	return r.serverMgr.Stop()
+}
+
+// RerankerAvailable checks if reranking is available without creating a full Reranker.
+func RerankerAvailable() bool {
+	mgr, err := NewRerankerManager()
+	if err != nil {
+		return false
+	}
+	return mgr.ModelExists()
+}
+
+// PrintStatus prints reranker status to stderr for debugging.
+func (r *Reranker) PrintStatus() {
+	if r.serverMgr == nil {
+		fmt.Fprintln(os.Stderr, "Reranker: no server manager")
+		return
+	}
+
+	running, pid, port := r.serverMgr.Status()
+	if running {
+		fmt.Fprintf(os.Stderr, "Reranker: running on port %d", port)
+		if pid > 0 {
+			fmt.Fprintf(os.Stderr, " (PID %d)", pid)
+		}
+		fmt.Fprintln(os.Stderr)
+	} else {
+		fmt.Fprintln(os.Stderr, "Reranker: not running")
+	}
+
+	if r.serverMgr.ModelExists() {
+		fmt.Fprintf(os.Stderr, "Model: %s\n", r.serverMgr.ModelPath())
+	} else {
+		fmt.Fprintln(os.Stderr, "Model: not downloaded (run 'sgrep setup --with-rerank')")
+	}
+}

--- a/pkg/rerank/reranker_test.go
+++ b/pkg/rerank/reranker_test.go
@@ -1,0 +1,201 @@
+package rerank
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestReranker_Rerank(t *testing.T) {
+	// Create a mock server that simulates llama.cpp /v1/rerank endpoint
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/rerank" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+
+		if r.Method != "POST" {
+			t.Errorf("unexpected method: %s", r.Method)
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		// Parse request
+		var req rerankRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		// Validate request
+		if req.Query == "" {
+			http.Error(w, "query required", http.StatusBadRequest)
+			return
+		}
+
+		// Create mock response - simulate ranking based on document order
+		results := make([]RerankResult, len(req.Documents))
+		for i := range req.Documents {
+			// Give higher scores to earlier documents (simulate relevance ranking)
+			results[i] = RerankResult{
+				Index: i,
+				Score: 1.0 - float64(i)*0.1,
+			}
+		}
+
+		resp := rerankResponse{
+			Model:   "mock-reranker",
+			Results: results,
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	// Create reranker with mock server
+	reranker := NewWithConfig(Config{
+		Endpoint:  server.URL,
+		Timeout:   5 * time.Second,
+		AutoStart: false, // Don't try to start real server
+	})
+
+	// Test reranking
+	ctx := context.Background()
+	query := "test query"
+	documents := []string{"doc1", "doc2", "doc3"}
+
+	results, err := reranker.Rerank(ctx, query, documents)
+	if err != nil {
+		t.Fatalf("Rerank failed: %v", err)
+	}
+
+	if len(results) != len(documents) {
+		t.Errorf("expected %d results, got %d", len(documents), len(results))
+	}
+
+	// Verify first document has highest score
+	if len(results) > 0 && results[0].Score < 0.9 {
+		t.Errorf("expected first document to have high score, got %f", results[0].Score)
+	}
+}
+
+func TestReranker_RerankTopK(t *testing.T) {
+	// Create mock server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req rerankRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		// Return results with varying scores
+		results := []RerankResult{
+			{Index: 0, Score: 0.5},
+			{Index: 1, Score: 0.9}, // Highest
+			{Index: 2, Score: 0.3},
+			{Index: 3, Score: 0.7},
+			{Index: 4, Score: 0.1},
+		}
+
+		_ = json.NewEncoder(w).Encode(rerankResponse{Results: results})
+	}))
+	defer server.Close()
+
+	reranker := NewWithConfig(Config{
+		Endpoint:  server.URL,
+		Timeout:   5 * time.Second,
+		AutoStart: false,
+	})
+
+	ctx := context.Background()
+	documents := []string{"a", "b", "c", "d", "e"}
+
+	// Get top 2
+	results, err := reranker.RerankTopK(ctx, "query", documents, 2)
+	if err != nil {
+		t.Fatalf("RerankTopK failed: %v", err)
+	}
+
+	if len(results) != 2 {
+		t.Errorf("expected 2 results, got %d", len(results))
+	}
+
+	// Verify results are sorted by score descending
+	if len(results) >= 2 {
+		if results[0].Score < results[1].Score {
+			t.Errorf("results not sorted by score: %f < %f", results[0].Score, results[1].Score)
+		}
+		// Index 1 should be first (highest score 0.9)
+		if results[0].Index != 1 {
+			t.Errorf("expected index 1 to be first, got index %d", results[0].Index)
+		}
+	}
+}
+
+func TestReranker_EmptyDocuments(t *testing.T) {
+	reranker := NewWithConfig(Config{
+		Endpoint:  "http://localhost:9999", // Won't be called
+		Timeout:   5 * time.Second,
+		AutoStart: false,
+	})
+
+	ctx := context.Background()
+	results, err := reranker.Rerank(ctx, "query", []string{})
+
+	if err != nil {
+		t.Errorf("expected no error for empty documents, got: %v", err)
+	}
+
+	if results != nil {
+		t.Errorf("expected nil results for empty documents, got: %v", results)
+	}
+}
+
+func TestReranker_ServerError(t *testing.T) {
+	// Create server that returns error
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	reranker := NewWithConfig(Config{
+		Endpoint:  server.URL,
+		Timeout:   5 * time.Second,
+		AutoStart: false,
+	})
+
+	ctx := context.Background()
+	_, err := reranker.Rerank(ctx, "query", []string{"doc1"})
+
+	if err == nil {
+		t.Error("expected error for server error response")
+	}
+}
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
+
+	if cfg.Endpoint != "http://localhost:8081" {
+		t.Errorf("expected default endpoint http://localhost:8081, got %s", cfg.Endpoint)
+	}
+
+	if cfg.Timeout != 30*time.Second {
+		t.Errorf("expected default timeout 30s, got %v", cfg.Timeout)
+	}
+
+	if !cfg.AutoStart {
+		t.Error("expected AutoStart to be true by default")
+	}
+}
+
+func TestRerankerAvailable(t *testing.T) {
+	// This will return false in test environment (no model downloaded)
+	available := RerankerAvailable()
+	// Just verify it doesn't panic
+	_ = available
+}

--- a/pkg/rerank/server.go
+++ b/pkg/rerank/server.go
@@ -1,0 +1,406 @@
+package rerank
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"syscall"
+	"time"
+)
+
+const (
+	DefaultRerankerPort    = 8081
+	DefaultHost            = "localhost"
+	RerankerModelURL       = "https://huggingface.co/gpustack/bge-reranker-v2-m3-GGUF/resolve/main/bge-reranker-v2-m3-Q8_0.gguf"
+	RerankerModelName      = "bge-reranker-v2-m3-Q8_0.gguf"
+	RerankerModelSize      = 636_000_000 // ~636MB
+	RerankerStartupTimeout = 30 * time.Second
+	RerankerHealthInterval = 500 * time.Millisecond
+)
+
+// RerankerManager handles llama.cpp reranker server lifecycle.
+type RerankerManager struct {
+	sgrepHome string
+	port      int
+	host      string
+}
+
+// NewRerankerManager creates a reranker server manager.
+func NewRerankerManager() (*RerankerManager, error) {
+	home, err := getSgrepHome()
+	if err != nil {
+		return nil, err
+	}
+
+	port := DefaultRerankerPort
+	if p := os.Getenv("SGREP_RERANKER_PORT"); p != "" {
+		if parsed, err := strconv.Atoi(p); err == nil {
+			port = parsed
+		}
+	}
+
+	return &RerankerManager{
+		sgrepHome: home,
+		port:      port,
+		host:      DefaultHost,
+	}, nil
+}
+
+// IsRunning checks if the reranker server is responding.
+func (m *RerankerManager) IsRunning() bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "GET", m.healthURL(), nil)
+	if err != nil {
+		return false
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return false
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	return resp.StatusCode == http.StatusOK
+}
+
+// Start starts the llama.cpp reranker server if not already running.
+func (m *RerankerManager) Start() error {
+	if m.IsRunning() {
+		return nil
+	}
+
+	// Check if llama-server binary exists
+	llamaPath, err := m.findLlamaServer()
+	if err != nil {
+		return err
+	}
+
+	// Check if model exists
+	modelPath := m.ModelPath()
+	if _, err := os.Stat(modelPath); os.IsNotExist(err) {
+		return fmt.Errorf("reranker model not found at %s. Run 'sgrep setup --with-rerank' first", modelPath)
+	}
+
+	// Clean up stale PID file
+	m.cleanStalePID()
+
+	// Start the server
+	logPath := filepath.Join(m.sgrepHome, "reranker.log")
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to open log file: %w", err)
+	}
+
+	// Calculate optimal settings based on CPU
+	numCPU := runtime.NumCPU()
+
+	threads := numCPU
+	if threads > 16 {
+		threads = 16
+	}
+
+	// For reranking, we need fewer parallel slots since each request has multiple documents
+	parallelSlots := 4
+	if numCPU >= 8 {
+		parallelSlots = 8
+	}
+
+	// Context size: 2048 tokens per slot
+	contextSize := parallelSlots * 2048
+
+	// Build command with reranking-specific flags
+	// Key difference from embedding server: --pooling rank enables reranking mode
+	args := []string{
+		"-m", modelPath,
+		"--embedding",
+		"--pooling", "rank", // CRITICAL: This enables reranking mode
+		"--port", strconv.Itoa(m.port),
+		"--host", m.host,
+		"-c", strconv.Itoa(contextSize),
+		"-b", "2048",
+		"-ub", "2048",
+		"--threads", strconv.Itoa(threads),
+		"-ngl", "99", // Use GPU if available
+		"-np", strconv.Itoa(parallelSlots),
+		"-cb", // Continuous batching
+	}
+
+	cmd := exec.Command(llamaPath, args...)
+
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setpgid: true, // Detach from parent process group
+	}
+
+	if err := cmd.Start(); err != nil {
+		_ = logFile.Close()
+		return fmt.Errorf("failed to start reranker server: %w", err)
+	}
+
+	// Write PID file
+	pidPath := m.pidPath()
+	if err := os.WriteFile(pidPath, []byte(strconv.Itoa(cmd.Process.Pid)), 0644); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: failed to write reranker PID file: %v\n", err)
+	}
+
+	// Wait for server to be ready
+	if err := m.waitForReady(); err != nil {
+		_ = m.Stop()
+		return err
+	}
+
+	return nil
+}
+
+// Stop stops the reranker server.
+func (m *RerankerManager) Stop() error {
+	pid, err := m.readPID()
+	if err != nil {
+		if m.IsRunning() {
+			return fmt.Errorf("reranker running but no PID file found; kill manually on port %d", m.port)
+		}
+		return nil
+	}
+
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		m.removePIDFile()
+		return nil
+	}
+
+	if err := proc.Signal(syscall.SIGTERM); err != nil {
+		m.removePIDFile()
+		return nil
+	}
+
+	time.Sleep(500 * time.Millisecond)
+
+	if m.IsRunning() {
+		_ = proc.Signal(syscall.SIGKILL)
+	}
+
+	m.removePIDFile()
+	return nil
+}
+
+// Status returns reranker server status info.
+func (m *RerankerManager) Status() (running bool, pid int, port int) {
+	port = m.port
+	running = m.IsRunning()
+	pid, _ = m.readPID()
+	return
+}
+
+// ModelPath returns the path to the reranker model.
+func (m *RerankerManager) ModelPath() string {
+	if customPath := os.Getenv("SGREP_RERANK_MODEL"); customPath != "" {
+		return customPath
+	}
+	return filepath.Join(m.sgrepHome, "models", RerankerModelName)
+}
+
+// ModelsDir returns the models directory.
+func (m *RerankerManager) ModelsDir() string {
+	return filepath.Join(m.sgrepHome, "models")
+}
+
+// Endpoint returns the reranker server endpoint URL.
+func (m *RerankerManager) Endpoint() string {
+	return fmt.Sprintf("http://%s:%d", m.host, m.port)
+}
+
+// EnsureRunning starts the reranker server if not running.
+func (m *RerankerManager) EnsureRunning() error {
+	if m.IsRunning() {
+		return nil
+	}
+	return m.Start()
+}
+
+// ModelExists checks if the reranker model is already downloaded.
+func (m *RerankerManager) ModelExists() bool {
+	info, err := os.Stat(m.ModelPath())
+	if err != nil {
+		return false
+	}
+	return info.Size() > 500_000_000 // Should be > 500MB
+}
+
+// DownloadModel downloads the reranker model if not present.
+func (m *RerankerManager) DownloadModel(progress func(downloaded, total int64)) error {
+	modelPath := m.ModelPath()
+
+	// Check if already exists
+	if info, err := os.Stat(modelPath); err == nil {
+		if info.Size() > 500_000_000 { // Sanity check: should be > 500MB
+			return nil
+		}
+		// File exists but seems incomplete, remove it
+		_ = os.Remove(modelPath)
+	}
+
+	// Create models directory
+	modelsDir := m.ModelsDir()
+	if err := os.MkdirAll(modelsDir, 0755); err != nil {
+		return fmt.Errorf("failed to create models directory: %w", err)
+	}
+
+	// Download to temp file first
+	tmpPath := modelPath + ".tmp"
+	defer func() { _ = os.Remove(tmpPath) }()
+
+	if err := downloadFile(tmpPath, RerankerModelURL, progress); err != nil {
+		return fmt.Errorf("reranker model download failed: %w", err)
+	}
+
+	// Rename to final location
+	if err := os.Rename(tmpPath, modelPath); err != nil {
+		return fmt.Errorf("failed to save reranker model: %w", err)
+	}
+
+	return nil
+}
+
+func (m *RerankerManager) healthURL() string {
+	return fmt.Sprintf("http://%s:%d/health", m.host, m.port)
+}
+
+func (m *RerankerManager) pidPath() string {
+	return filepath.Join(m.sgrepHome, "reranker.pid")
+}
+
+func (m *RerankerManager) readPID() (int, error) {
+	data, err := os.ReadFile(m.pidPath())
+	if err != nil {
+		return 0, err
+	}
+	return strconv.Atoi(string(data))
+}
+
+func (m *RerankerManager) removePIDFile() {
+	_ = os.Remove(m.pidPath())
+}
+
+func (m *RerankerManager) cleanStalePID() {
+	pid, err := m.readPID()
+	if err != nil {
+		return
+	}
+
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		m.removePIDFile()
+		return
+	}
+
+	if err := proc.Signal(syscall.Signal(0)); err != nil {
+		m.removePIDFile()
+	}
+}
+
+func (m *RerankerManager) waitForReady() error {
+	deadline := time.Now().Add(RerankerStartupTimeout)
+	for time.Now().Before(deadline) {
+		if m.IsRunning() {
+			return nil
+		}
+		time.Sleep(RerankerHealthInterval)
+	}
+	return fmt.Errorf("reranker server failed to start within %v", RerankerStartupTimeout)
+}
+
+func (m *RerankerManager) findLlamaServer() (string, error) {
+	names := []string{"llama-server", "llama-server-metal", "server"}
+
+	for _, name := range names {
+		if path, err := exec.LookPath(name); err == nil {
+			return path, nil
+		}
+	}
+
+	brewPaths := []string{
+		"/opt/homebrew/bin/llama-server",
+		"/usr/local/bin/llama-server",
+	}
+	for _, p := range brewPaths {
+		if _, err := os.Stat(p); err == nil {
+			return p, nil
+		}
+	}
+
+	return "", fmt.Errorf("llama-server not found. Install with: brew install llama.cpp")
+}
+
+func getSgrepHome() (string, error) {
+	if home := os.Getenv("SGREP_HOME"); home != "" {
+		return home, nil
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(homeDir, ".sgrep"), nil
+}
+
+func downloadFile(filepath string, url string, progress func(downloaded, total int64)) error {
+	client := &http.Client{
+		Timeout: 30 * time.Minute,
+	}
+
+	resp, err := client.Get(url)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("download returned status %d", resp.StatusCode)
+	}
+
+	out, err := os.Create(filepath)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = out.Close() }()
+
+	total := resp.ContentLength
+	if total <= 0 {
+		total = RerankerModelSize
+	}
+
+	var downloaded int64
+	buf := make([]byte, 32*1024)
+
+	for {
+		n, err := resp.Body.Read(buf)
+		if n > 0 {
+			_, writeErr := out.Write(buf[:n])
+			if writeErr != nil {
+				return writeErr
+			}
+			downloaded += int64(n)
+			if progress != nil {
+				progress(downloaded, total)
+			}
+		}
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/store/types.go
+++ b/pkg/store/types.go
@@ -58,6 +58,11 @@ type FileEmbeddingStorer interface {
 	DeleteFileEmbedding(ctx context.Context, filePath string) error
 }
 
+// FileEmbeddingComputer is an optional interface for stores that can compute file embeddings from chunks.
+type FileEmbeddingComputer interface {
+	ComputeAndStoreFileEmbeddings(ctx context.Context) (int, error)
+}
+
 // FileEmbedding represents a document-level embedding for a file.
 type FileEmbedding struct {
 	FilePath   string

--- a/pkg/store/types.go
+++ b/pkg/store/types.go
@@ -49,6 +49,23 @@ func EnsureFTS5IfNeeded(s Storer) error {
 	return nil
 }
 
+// FileEmbeddingStorer is an optional interface for stores that support document-level embeddings.
+type FileEmbeddingStorer interface {
+	StoreFileEmbedding(ctx context.Context, fe *FileEmbedding) error
+	StoreFileEmbeddingBatch(ctx context.Context, fes []*FileEmbedding) error
+	SearchFileEmbeddings(ctx context.Context, embedding []float32, limit int, threshold float64) ([]string, []float64, error)
+	GetChunksByFilePath(ctx context.Context, filePath string) ([]*Document, error)
+	DeleteFileEmbedding(ctx context.Context, filePath string) error
+}
+
+// FileEmbedding represents a document-level embedding for a file.
+type FileEmbedding struct {
+	FilePath   string
+	Embedding  []float32
+	ChunkCount int
+	TotalLines int
+}
+
 // Document represents an indexed code chunk.
 type Document struct {
 	ID        string


### PR DESCRIPTION
## Summary

Adds two-stage retrieval with cross-encoder reranking to improve search quality, plus document-level embeddings for meta-queries.

Closes #1

## Changes

### Cross-Encoder Reranking
- Integrate BGE-reranker-v2-m3 via llama.cpp server for two-stage retrieval
- RRF (Reciprocal Rank Fusion) combining vector search rank with reranker scores
- Sigmoid normalization for cross-encoder logits
- Query intent detection (conceptual/definition/procedural/example)
- Code signal boosting based on file path patterns

### Document-Level Embeddings
- Add `file_embeddings` table with DiskANN vector index
- Compute mean embedding per file during indexing
- Automatic fallback for meta-queries like "what does this repo do"
- README.md now ranks #1 for repository overview queries

### Performance Optimizations
- Limit rerank candidates (50 → 30 fetched, 15 actually reranked)
- Achieves 2-6x speedup: ~1.4s down to 250-680ms

## Test Results

```bash
# Quality: error handling query
./sgrep --rerank "error handling"
# pkg/errors/errors.go ranks #1 ✓

# Quality: meta-query
./sgrep "what does this repo do"  
# README.md:1-174 ranks #1 ✓

# Performance
./sgrep -d --rerank "error handling"
# Completes in ~257ms ✓
```

## Files Changed
- `pkg/rerank/` - New reranker package (server management + client)
- `pkg/store/libsql.go` - file_embeddings table and methods
- `pkg/store/types.go` - FileEmbeddingStorer interface
- `pkg/index/index.go` - compute file embeddings during indexing
- `pkg/search/search.go` - RRF fusion, document-level search, intent detection
- `internal/cli/root.go` - `--rerank` flag and setup commands